### PR TITLE
add: topic identification based on parent nodes

### DIFF
--- a/src/willa/core.clj
+++ b/src/willa/core.clj
@@ -94,7 +94,8 @@
             (::window entity) (ws/window-by (::window entity))
             (::aggregate-adder-fn entity) (ws/aggregate (::aggregate-initial-value entity)
                                                         (::aggregate-adder-fn entity)
-                                                        (::aggregate-subtractor-fn entity))
+                                                        (::aggregate-subtractor-fn entity)
+                                                        (str (hash parents)))
             true (ws/coerce-to-ktable)
             (::suppression entity) (ws/suppress (::suppression entity)))))
 

--- a/src/willa/streams.clj
+++ b/src/willa/streams.clj
@@ -32,10 +32,10 @@
                                           default-serdes))))
 
 
-(defn aggregate [aggregatable initial-value adder-fn subtractor-fn]
-  (let [topic-config (merge {:topic-name (str (gensym))}
+(defn aggregate [aggregatable initial-value adder-fn subtractor-fn name]
+  (let [topic-config (merge {:topic-name name}
                             default-serdes)]
-    (if (instance? CljKGroupedTable aggregatable)
+   (if (instance? CljKGroupedTable aggregatable)
       (streams/aggregate
         aggregatable
         (constantly initial-value)

--- a/test/willa/unit/streams_test.clj
+++ b/test/willa/unit/streams_test.clj
@@ -32,7 +32,7 @@
 
     (-> (streams/kstream builder input-topic)
         (streams/group-by-key)
-        (aggregate 0 (fn [acc [k v]] (+ acc v)) identity)
+        (aggregate 0 (fn [acc [k v]] (+ acc v)) identity "aggregate")
         (streams/to-kstream)
         (streams/to output-topic))
 


### PR DESCRIPTION
The reasoning behind this is that the previous gensym implementation
created multiple -changelog topics in my kafka cluster whenever I put
up a new version of my topology. Ultimately resulting in data loss when
the system tried to restore the data stores, since it will read from a
newly created -changelog topic. 
With this naming based on parent nodes, I expect  that the system will
keep the previous  changelog topics, as long as my parent nodes wont
change