### PR TITLE
Add support for GlobalKTables

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ The code looks like this:
 | Key | Description |
 | --- | --- |
 | `:willa.core/join-type` | The type of the join. Can be one of `:merge`, `:left`, `:inner` or `:outer`.|
-| `:willa.core/window` | A [JoinWindows](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/JoinWindows.html) object that specifies the windowing to be used in the join. Not used when the join type is `:merge` |     
+| `:willa.core/window` | A [JoinWindows](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/JoinWindows.html) object that specifies the windowing to be used in the join. Not used when the join type is `:merge` or when one of the join objects is a `:global-ktable` |     
+| `:willa.core/kv-mapper` | The [kv-mapper function](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KeyValueMapper.html) to use when joining a `:kstream` with a `:global-ktable`. Extracts a key of the GlobalKTable from each `[k v]` of the stream. If not specified, the key of the stream is used. Not used when joining other kinds of objects. See [the Kafka Streams docs](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KStream.html#join-org.apache.kafka.streams.kstream.GlobalKTable-org.apache.kafka.streams.kstream.KeyValueMapper-org.apache.kafka.streams.kstream.ValueJoiner-) for more info |     
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The code looks like this:
 ### Entity Config
 | Key | Required? | Valid Entity Types | Description |
 | --- | --- | --- | --- |
-| `:willa.core/entity-type` | ☑ | All | The type of the entity. Can be one of: `:topic`, `:kstream`, or `:ktable`| 
+| `:willa.core/entity-type` | ☑ | All | The type of the entity. Can be one of: `:topic`, `:kstream`, `:ktable`, or `:global-ktable`| 
 | `:topic-name` | ☑ | `:topic` | The name of the topic |
 | `:key-serde` | ☑ | `:topic` | The serde to use to serialize/deserialize the keys of records on the topic |
 | `:value-serde` | ☑ | `:topic` | The serde to use to serialize/deserialize the values of records on the topic |

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The code looks like this:
 | Key | Description |
 | --- | --- |
 | `:willa.core/join-type` | The type of the join. Can be one of `:merge`, `:left`, `:inner` or `:outer`.|
-| `:willa.core/window` | A [JoinWindows](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/JoinWindows.html) object that specifies the windowing to be used in the join. Not used when the join type is `:merge` or when one of the join objects is a `:global-ktable` |     
+| `:willa.core/window` | A [JoinWindows](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/JoinWindows.html) object that specifies the windowing to be used in the join. Not used when the join type is `:merge` or when joining a `:kstream` and a `:global-ktable` |     
 | `:willa.core/kv-mapper` | The [kv-mapper function](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KeyValueMapper.html) to use when joining a `:kstream` with a `:global-ktable`. Extracts a key of the GlobalKTable from each `[k v]` of the stream. If not specified, the key of the stream is used. Not used when joining other kinds of objects. See [the Kafka Streams docs](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KStream.html#join-org.apache.kafka.streams.kstream.GlobalKTable-org.apache.kafka.streams.kstream.KeyValueMapper-org.apache.kafka.streams.kstream.ValueJoiner-) for more info |     
 
 ## License

--- a/src/willa/core.clj
+++ b/src/willa/core.clj
@@ -49,6 +49,9 @@
 (defmethod ->joinable :ktable [builder entity]
   (entity->ktable builder entity))
 
+(defmethod ->joinable :global-ktable [builder entity]
+  (::kstreams-object entity))
+
 
 (def ->groupable ->joinable)
 
@@ -102,11 +105,11 @@
 
 (defmethod build-kstreams-object :global-ktable [entity builder parents entities joins]
   (if (wu/single-elem? parents)
-    (let [parent (first parents)
+    (let [parent (get entities (first parents))
           parent-type (::entity-type parent)]
       (if (= :topic parent-type)
         (streams/global-ktable builder parent)
-        (throw (ex-info (str "GlobalKTable's source must be a :topic and not a " parent-type)
+        (throw (ex-info (str "GlobalKTable's source must be a :topic and not a " (or parent-type "nil"))
                         {:entity entity :parents parents}))))
     (throw (ex-info "GlobalKTable can only have one source (i.e. no joins)"
                     {:entity entity :parents parents}))))

--- a/src/willa/core.clj
+++ b/src/willa/core.clj
@@ -100,6 +100,18 @@
             (::suppression entity) (ws/suppress (::suppression entity)))))
 
 
+(defmethod build-kstreams-object :global-ktable [entity builder parents entities joins]
+  (if (wu/single-elem? parents)
+    (let [parent (first parents)
+          parent-type (::entity-type parent)]
+      (if (= :topic parent-type)
+        (streams/global-ktable builder parent)
+        (throw (ex-info (str "GlobalKTable's source must be a :topic and not a " parent-type)
+                        {:entity entity :parents parents}))))
+    (throw (ex-info "GlobalKTable can only have one source (i.e. no joins)"
+                    {:entity entity :parents parents}))))
+
+
 
 (defn- build-topology!* [builder {:keys [workflow entities joins]} overrides]
   (let [g (wu/->graph workflow)]

--- a/src/willa/streams.clj
+++ b/src/willa/streams.clj
@@ -1,7 +1,7 @@
 (ns willa.streams
   (:require [jackdaw.streams :as streams]
             [jackdaw.serdes.edn :as serdes.edn])
-  (:import (jackdaw.streams.interop CljKTable CljKStream CljKGroupedTable)
+  (:import (jackdaw.streams.interop CljKTable CljKStream CljKGroupedTable CljGlobalKTable)
            (org.apache.kafka.streams.kstream Transformer SessionWindows TimeWindows KTable)
            (org.apache.kafka.streams.processor ProcessorContext)))
 
@@ -94,6 +94,16 @@
   [:left CljKStream CljKTable]
   [_ kstream ktable join-fn]
   (streams/left-join kstream ktable join-fn default-serdes default-serdes))
+
+(defmethod join*
+  [:inner CljKStream CljGlobalKTable]
+  [_ kstream global-ktable join-fn]
+  (streams/join-global kstream global-ktable (fn [[k v]] k) join-fn))
+
+(defmethod join*
+  [:left CljKStream CljGlobalKTable]
+  [_ kstream global-ktable join-fn]
+  (streams/left-join-global kstream global-ktable (fn [[k v]] k) join-fn))
 
 
 (defn join

--- a/src/willa/streams.clj
+++ b/src/willa/streams.clj
@@ -97,13 +97,13 @@
 
 (defmethod join*
   [:inner CljKStream CljGlobalKTable]
-  [_ kstream global-ktable join-fn]
-  (streams/join-global kstream global-ktable (fn [[k v]] k) join-fn))
+  [{kv-mapper :willa.core/kv-mapper, :or {kv-mapper first}} kstream global-ktable join-fn]
+  (streams/join-global kstream global-ktable kv-mapper join-fn))
 
 (defmethod join*
   [:left CljKStream CljGlobalKTable]
-  [_ kstream global-ktable join-fn]
-  (streams/left-join-global kstream global-ktable (fn [[k v]] k) join-fn))
+  [{kv-mapper :willa.core/kv-mapper, :or {kv-mapper first}} kstream global-ktable join-fn]
+  (streams/left-join-global kstream global-ktable kv-mapper join-fn))
 
 
 (defn join

--- a/test/willa/unit/core_test.clj
+++ b/test/willa/unit/core_test.clj
@@ -80,3 +80,40 @@
                                  (= 1 (count (get-in journal [:topics "output"])))))
 
         {:output-topic [{:key "k" :value 1}]})))
+
+(deftest global-ktable-topology-tests
+  (is (u/results-congruous?
+       [:output-topic]
+       (u/run-tm-for-workflow {:workflow [[:input-topic :joined-stream]
+                                          [:table-input-topic :global-table]
+                                          [:global-table :joined-stream]
+                                          [:joined-stream :output-topic]]
+                               :entities {:input-topic (u/->topic "input")
+                                          :table-input-topic (u/->topic "table-input")
+                                          :global-table {:willa.core/entity-type :global-ktable}
+                                          :joined-stream {:willa.core/entity-type :kstream}
+                                          :output-topic (u/->topic "output")}
+                               :joins {[:input-topic :global-table] {:willa.core/join-type :inner}}}
+                              {:input-topic [{:key "k" :value 1 :timestamp 100}]
+                               :table-input-topic [{:key "k" :value 2 :timestamp 0}]}
+                              (fn [journal]
+                                (= 1 (count (get-in journal [:topics "output"])))))
+       {:output-topic [{:key "k" :value [1 2]}]}))
+
+  (is (u/results-congruous?
+       [:output-topic]
+       (u/run-tm-for-workflow {:workflow [[:input-topic :joined-stream]
+                                          [:table-input-topic :global-table]
+                                          [:global-table :joined-stream]
+                                          [:joined-stream :output-topic]]
+                               :entities {:input-topic (u/->topic "input")
+                                          :table-input-topic (u/->topic "table-input")
+                                          :global-table {:willa.core/entity-type :global-ktable}
+                                          :joined-stream {:willa.core/entity-type :kstream}
+                                          :output-topic (u/->topic "output")}
+                               :joins {[:input-topic :global-table] {:willa.core/join-type :left}}}
+                              {:input-topic [{:key "k" :value 1 :timestamp 100} {:key "k2" :value 1 :timestamp 101}]
+                               :table-input-topic [{:key "k2" :value 2 :timestamp 0}]}
+                              (fn [journal]
+                                (= 2 (count (get-in journal [:topics "output"])))))
+       {:output-topic [{:key "k" :value [1 nil]} {:key "k2" :value [1 2]}]})))


### PR DESCRIPTION
Adds an entity type for GlobalKTables and supports inner & left join with KStreams and a custom kv-mapper in join config so the KStream doesn't have to be re-keyed before joining with a GlobalKTable.

I added a few topology tests with GlobalKTables.