### PR TITLE
Add support for custom state-store name on ktable entities.

### DIFF
--- a/src/willa/core.clj
+++ b/src/willa/core.clj
@@ -99,7 +99,7 @@
                                                         (::aggregate-adder-fn entity)
                                                         (::aggregate-subtractor-fn entity)
                                                         (str (hash parents)))
-            true (ws/coerce-to-ktable)
+            true (ws/coerce-to-ktable (select-keys entity [:store-name]))
             (::suppression entity) (ws/suppress (::suppression entity)))))
 
 


### PR DESCRIPTION
Previously, when defining a ktable entity, there was no option to name the state store. The default behavior was to generate a topic-name with gensym.

Now, `:store-name` may be provided when :ktable is the entity type. When not provided, the previous default behavior is used where the store name is a gensym string.

Ex.

```clojure
{::w/entity-type :ktable
 :store-name "my-store"}
```

This implementation avoids breaking existing single-arity callers of `coerce-to-ktable` by placing a multi-arity function in-front of the existing multi-method, and adding a star behind the multi-method name. I ran through the tests and they pass.

I made a choice to use terminology like 'state-store-config' and 'store-name' in places where I thought it made sense to make it clear the operation is about state stores instead of using the terminology 'topic-config' which is ultimately what the data structure turns out to be. At the lowest level (the multi-method) it is called topic-config, however, because the jackdaw function refers to it as a topic-config.

I did not allow serdes to pass through in the state-store-config because I wasn't sure how that fit in with other operations, but it's something that can easily be allowed by adding the right keys to this line `(ws/coerce-to-ktable (select-keys entity [:store-name]))`.

Lastly, instead of accepting a single arg, the `coerce-to-ktable*` multi-method accepts both the kstreams-object and a topic-config now. The only place this was less than ideal was in the method impl that accepts a plain ktable, but the additional arg is easily ignored.

I will be making an issue right after submitting this. Apologies in advance if there is a standard way to name your state store when making a ktable with Willa, I could not find reference to it anywhere.

Let me know if I can tune this branch for you. I think it's in a good condition to merge it if you like it, but if you would like me to add some tests, or you have concerns about how it affects the rest of the system I'm happy to help.
